### PR TITLE
修复统一战线党派名称不正确问题

### DIFF
--- a/common/national_focus/MVLV_CHI.txt
+++ b/common/national_focus/MVLV_CHI.txt
@@ -509,8 +509,8 @@ focus_tree = {
 			custom_effect_tooltip = CHI_idea_12_S5_tt
 			set_party_name = {
 				ideology = democratic
-				long_name = CHI_democratic_party_long
-				name = CHI_democratic_party
+				long_name = CHI_UFC_democratic_party_long
+				name = CHI_UFC_democratic_party
 			}
 			hidden_effect = {
 				set_cosmetic_tag = CHI_warlord_leader

--- a/localisation/english/replace/MVLV_parties_l_english.yml
+++ b/localisation/english/replace/MVLV_parties_l_english.yml
@@ -1,3 +1,5 @@
-﻿l_english:
-  CHI_democratic_party:0 "中国民主同盟"
-  CHI_democratic_party_long:0 "中国民主同盟"
+﻿l_simp_chinese:
+  CHI_democratic_party:0 "统一中华战线"
+  CHI_democratic_party_long:0 "统一中华战线"
+  CHI_UFC_democratic_party:0 "中华联合政府"
+  CHI_UFC_democratic_party_long:0 "中华联合政府"

--- a/localisation/simp_chinese/replace/MVLV_parties_l_simp_chinese.yml
+++ b/localisation/simp_chinese/replace/MVLV_parties_l_simp_chinese.yml
@@ -1,3 +1,5 @@
 ﻿l_simp_chinese:
-  CHI_democratic_party:0 "中国民主同盟"
-  CHI_democratic_party_long:0 "中国民主同盟"
+  CHI_democratic_party:0 "统一中华战线"
+  CHI_democratic_party_long:0 "统一中华战线"
+  CHI_UFC_democratic_party:0 "中华联合政府"
+  CHI_UFC_democratic_party_long:0 "中华联合政府"


### PR DESCRIPTION
点国策共和国前民主党派名称应该为统一中华战线，点国策共和国后民主党派名称应该为中华联合政府。原先显示有问题